### PR TITLE
App launches in the center of the screen on Windows

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,12 +35,12 @@ h1 {
 
 #quit-app-button {
   color:#fff;
-  opacity: 0.7;
+  opacity: 0.9;
   position: absolute;
   bottom: 20px;
   left: 50%;
   transform: translateX(-50%);
-  font-size: 12px;
+  font-size: 16px;
   text-decoration: none;
 }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict'
-require('dotenv').config();
+//require('dotenv').config();
 const ipcRenderer = require('electron').ipcRenderer;
 
 const wireUpButtons = () => {
@@ -20,11 +20,7 @@ const wireUpButtons = () => {
 
    const url = 'https://api.github.com/zen';
    var request = new Request(url, {
-      method: 'GET',
-      headers: new Headers({
-          "User-Agent" : "saraford",
-          "Authorization" : "token " + process.env.TOKEN,
-         })
+      method: 'GET'
     });
 
      window.fetch(request).then(function(response) {

--- a/main.js
+++ b/main.js
@@ -1,11 +1,14 @@
 'use strict';
 
 const {app, BrowserWindow, ipcMain, Tray} = require('electron');
+const electron = require('electron');
 
 var tray = undefined;
 var mainWindow = undefined;
+var screen_size = undefined;
 
 app.on('ready', function() {
+    screen_size = electron.screen.getPrimaryDisplay().workAreaSize
     createTray();
     createWindow();
 });
@@ -42,15 +45,29 @@ const showWindow = () => {
 
 const getWindowPosition = () => {
   const windowBounds = mainWindow.getBounds()
-  const trayBounds = tray.getBounds()
 
-  // Center window horizontally below the tray icon
-  const x = Math.round(trayBounds.x + (trayBounds.width / 2) - (windowBounds.width / 2))
+// place based on OS because tray is at different locations
+  if (process.platform == 'darwin') {
+    // place directly under the icon at the top 
+    const trayBounds = tray.getBounds()
 
-  // Position window 4 pixels vertically below the tray icon
-  const y = Math.round(trayBounds.y + trayBounds.height + 4)
+    // Center window horizontally below the tray icon
+    const x = Math.round(trayBounds.x + (trayBounds.width / 2) - (windowBounds.width / 2))
 
-  return {x: x, y: y}
+    // Position window 4 pixels vertically below the tray icon
+    const y = Math.round(trayBounds.y + trayBounds.height + 4)
+
+    return {x: x, y: y}
+  } 
+  else {
+    // place center on screen because my taskbar is docked to the right
+    // instead of the usual at the bottom
+    
+    const x = Math.round((screen_size.width / 2) - (windowBounds.width / 2));
+    const y = Math.round((screen_size.height / 2) - (windowBounds.height / 2));
+
+    return {x: x, y: y}
+  }
 }
 
 const createWindow = () => {
@@ -71,7 +88,7 @@ const createWindow = () => {
   })
 
   mainWindow.loadURL('file://' + __dirname + '/index.html');
-  mainWindow.webContents.openDevTools();
+  //mainWindow.webContents.openDevTools();
 
 
   // Hide the window when it loses focus


### PR DESCRIPTION
This is a proposed fix for #3.

Also contained in this PR:

- disabled showing dev tools
- using unauthenticated API calls, so anyone can quickly give it a try
- made the Quit this App link a big more discoverable